### PR TITLE
Add data-sbgl-navxml to generate XML files without HTML tags.

### DIFF
--- a/sblg.in.1
+++ b/sblg.in.1
@@ -403,7 +403,9 @@ file, it will be to an XML file!
 The navigation element may contain several attributes.
 The Boolean
 .Li data-sbgl-navcontent
-attribute makes the mark-up content of the
+and
+.Li data-sbgl-navxml
+attributes make the mark-up content of the
 .Li <nav>
 be processed as specified in
 .Sx Tag Symbols .
@@ -411,6 +413,14 @@ If not specified,
 .Nm
 populates the list with article title text in a link and the publication
 date.
+The
+.Li data-sbgl-navxml
+attribute does not print any additional
+.Li <nav> ,
+.Li <ul> ,
+or
+.Li <li>
+HTML tags and can be used to generate custom XML files, such as sitemaps.
 If the
 .Li <nav>
 element contains a positive integer


### PR DESCRIPTION
What about adding the possibility to generate basically any XML with sblg?

This experimental feature allows to generate a sitemap.xml using the nav tag. It parses the Tag Symbols and works like a nav, but skips printing the actual nav, ul, and li elements.  It could eventually also be used for custom non-Atom feeds using a template.

    sblg -t templates/sitemap.xml $(ARTICLES)

The output of this mode could be better, the generated indentation and whitespace of this diff is wrong but the result just works fine. Maybe you have better ideas? See https://reykfloeter.com/sitemap.xml (output) and https://reykfloeter.com/templates/sitemap.xml (input) as an example.

btw., I tried to match your C style - which is not strictly style(9) but maybe it is KNF (kristaps normal form) ;-)