### PR TITLE
Typo and missing flag-macro for version in manpage

### DIFF
--- a/sblg.in.1
+++ b/sblg.in.1
@@ -206,8 +206,8 @@ for
 and
 .Ar blog-template.xml
 otherwise.
-.It V
-Emits the verion as
+.It Fl V
+Emits the version as
 .Li sblg-xx.yy.zz
 and exits.
 .It Ar


### PR DESCRIPTION
Minor changes in the manpage:
 verion -> version
 add .Fl to the flag V